### PR TITLE
Fix: Route Name Mismatch on Transaction Form (Issue #54)

### DIFF
--- a/resources/views/livewire/transactions/transaction-form.blade.php
+++ b/resources/views/livewire/transactions/transaction-form.blade.php
@@ -37,7 +37,7 @@
                     Anda belum memiliki rekening (Tunai/Bank). Silakan buat rekening terlebih dahulu untuk mulai mencatat transaksi.
                 </p>
                 <div class="mt-8">
-                    <a href="{{ route('accounts.index') }}" 
+                    <a href="{{ route('account.index') }}" 
                        class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-indigo-600 text-white text-sm font-semibold shadow-lg shadow-indigo-200 hover:bg-indigo-500 transition-all duration-200">
                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />


### PR DESCRIPTION
This PR fixes a RouteNotFoundException that occurs when a user without any accounts opens the transaction form. The typo 'accounts.index' was corrected to 'account.index'.