### PR TITLE
Fix: Prevent duplicate budget for same category and month (#60)

### DIFF
--- a/app/Livewire/Budgets/BudgetForm.php
+++ b/app/Livewire/Budgets/BudgetForm.php
@@ -70,11 +70,14 @@ class BudgetForm extends Component
     {
         $this->validate();
         
+        $month = (int) now()->format('n');
+        $year  = (int) now()->format('Y');
+
         $data = [
             'category_id'  => $this->category_id,
             'limit_amount' => (int) $this->limit_amount,
-            'month'        => (int) now()->format('n'),
-            'year'         => (int) now()->format('Y'),
+            'month'        => $month,
+            'year'         => $year,
         ];
 
         if ($this->isEditing()) {
@@ -88,6 +91,17 @@ class BudgetForm extends Component
             $this->dispatch('close-modal', 'budget-updated');
             $this->dispatch('budget-updated');  
         }else {
+            $exists = Budget::where('user_id', Auth::id())
+                ->where('category_id', $this->category_id)
+                ->where('month', $month)
+                ->where('year', $year)
+                ->exists();
+
+            if ($exists) {
+                $this->addError('category_id', 'Kategori ini sudah memiliki budget di bulan ini.');
+                return;
+            }
+
             Budget::create(array_merge($data, ['user_id' => auth()->id()]));
             $this->notify('Berhasil!', 'Budget berhasil dibuat', 'success');
             $this->dispatch('budget-created');

--- a/tests/Feature/Feature/Livewire/Budgets/BudgetTest.php
+++ b/tests/Feature/Feature/Livewire/Budgets/BudgetTest.php
@@ -81,4 +81,27 @@ class BudgetTest extends TestCase
 
         $this->assertDatabaseMissing('budgets', ['id' => $budget->id]);
     }
+
+    #[Test]
+    public function tidak_bisa_membuat_budget_duplikat_di_bulan_yang_sama(): void
+    {
+        // Buat budget pertama untuk kategori ini
+        Budget::factory()->create([
+            'user_id'     => $this->user->id,
+            'category_id' => $this->cat->id,
+            'month'       => (int) now()->format('n'),
+            'year'        => (int) now()->format('Y'),
+        ]);
+
+        // Coba buat budget kedua untuk kategori yang sama → harus gagal
+        Livewire::actingAs($this->user)
+            ->test(BudgetForm::class)
+            ->set('category_id', $this->cat->id)
+            ->set('limit_amount', 2000000)
+            ->call('save')
+            ->assertHasErrors(['category_id']);
+
+        // Pastikan tetap hanya 1 record di database
+        $this->assertDatabaseCount('budgets', 1);
+    }
 }


### PR DESCRIPTION
This PR adds validation to prevent creating multiple budgets for the same category within the same month and year. It includes a new unit test to verify the fix.