### PR TITLE
Refactor: Rename loadBudget to setBudget for naming consistency (#62)

### DIFF
--- a/app/Livewire/Budgets/Delete.php
+++ b/app/Livewire/Budgets/Delete.php
@@ -15,7 +15,7 @@ class Delete extends Component
     public string $categoryName = '';
 
     #[On('delete-budget')]
-    public function loadBudget(int $id): void
+    public function setBudget(int $id): void
     {
         $budget = Budget::with('category')
             ->where('user_id', Auth::id())


### PR DESCRIPTION
This PR renames the loadBudget method to setBudget in Budget Delete component to match the setTransaction pattern used elsewhere. This also fix the failing unit test budget_otomatis_terhapus_jika_id_ditemukan.