### PR TITLE
Fix: Change category_id foreign key to cascade delete for user account deletion (#64)

### DIFF
--- a/database/migrations/2026_04_04_132212_fix_cascade_delete_on_category_foreign_keys.php
+++ b/database/migrations/2026_04_04_132212_fix_cascade_delete_on_category_foreign_keys.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // 1. Ubah foreign key category_id pada tabel transactions
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropForeign(['category_id']);
+            $table->foreign('category_id')
+                  ->references('id')
+                  ->on('categories')
+                  ->cascadeOnDelete();
+        });
+
+        // 2. Ubah foreign key category_id pada tabel favorite_transactions
+        Schema::table('favorite_transactions', function (Blueprint $table) {
+            $table->dropForeign(['category_id']);
+            $table->foreign('category_id')
+                  ->references('id')
+                  ->on('categories')
+                  ->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Kembalikan ke restrictOnDelete
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropForeign(['category_id']);
+            $table->foreign('category_id')
+                  ->references('id')
+                  ->on('categories')
+                  ->restrictOnDelete();
+        });
+
+        Schema::table('favorite_transactions', function (Blueprint $table) {
+            $table->dropForeign(['category_id']);
+            $table->foreign('category_id')
+                  ->references('id')
+                  ->on('categories')
+                  ->restrictOnDelete();
+        });
+    }
+};

--- a/tests/Feature/Feature/Livewire/Profile/DeleteUserTest.php
+++ b/tests/Feature/Feature/Livewire/Profile/DeleteUserTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature\Livewire\Profile;
+
+use App\Models\Budget;
+use App\Models\Category;
+use App\Models\Account;
+use App\Models\FavoriteTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DeleteUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function user_bisa_dihapus_meskipun_punya_transaksi(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::factory()->create(['user_id' => $user->id]);
+        $account = Account::factory()->create(['user_id' => $user->id]);
+
+        // Buat transaksi dan favorite transaction
+        Transaction::factory()->create([
+            'user_id' => $user->id,
+            'category_id' => $category->id,
+            'account_id' => $account->id,
+        ]);
+
+        FavoriteTransaction::create([
+            'user_id' => $user->id,
+            'category_id' => $category->id,
+            'name' => 'Test Favorite',
+            'amount' => 50000,
+            'type' => 'expense',
+        ]);
+
+        Budget::factory()->create([
+            'user_id' => $user->id,
+            'category_id' => $category->id,
+        ]);
+
+        // Hapus user — tidak boleh ada exception
+        $user->delete();
+
+        // Verifikasi semua data milik user sudah terhapus
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+        $this->assertDatabaseMissing('categories', ['user_id' => $user->id]);
+        $this->assertDatabaseMissing('transactions', ['user_id' => $user->id]);
+        $this->assertDatabaseMissing('favorite_transactions', ['user_id' => $user->id]);
+        $this->assertDatabaseMissing('budgets', ['user_id' => $user->id]);
+    }
+}


### PR DESCRIPTION
This PR fixes the Integrity Constraint Violation when deleting a user account by changing the category_id foreign key from restrictOnDelete to cascadeOnDelete in both transactions and favorite_transactions tables. It also includes a new unit test to verify the fix.