### PR TITLE
Protect account deletion with existing transactions

### DIFF
--- a/app/Livewire/Accounts/AccountList.php
+++ b/app/Livewire/Accounts/AccountList.php
@@ -3,10 +3,12 @@
 namespace App\Livewire\Accounts;
 
 use App\Models\Account;
+use App\Traits\WithNotifications;
 use Livewire\Component;
 
 class AccountList extends Component
 {
+    use WithNotifications;
     protected $listeners = [
         'account-saved' => '$refresh',
         'transaction-deleted' => '$refresh',
@@ -40,13 +42,15 @@ class AccountList extends Component
     public function deleteAccount(int $id): void
     {
         $account = Account::findOrFail($id);
+
+        if ($account->transactions()->exists() || \App\Models\Transaction::where('to_account_id', $id)->exists()) {
+            $this->notify('Gagal menghapus', "Rekening {$account->name} tidak dapat dihapus karena masih memiliki riwayat transaksi.", 'error');
+            return;
+        }
+
         $account->delete();
 
-        $this->dispatch('notify', [
-            'type'    => 'success',
-            'title'   => 'Rekening dihapus',
-            'message' => "Rekening {$account->name} berhasil dihapus.",
-        ]);
+        $this->notify('Rekening dihapus', "Rekening {$account->name} berhasil dihapus.", 'success');
     }
     public function render()
     {

--- a/database/migrations/2026_03_20_210309_create_transactions_table.php
+++ b/database/migrations/2026_03_20_210309_create_transactions_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
                 $table->id();
                 $table->foreignId('user_id')->constrained()->cascadeOnDelete();
                 $table->foreignId('category_id')->constrained('categories')->restrictOnDelete();
-                $table->foreignId('account_id')->constrained()->cascadeOnDelete();
+                $table->foreignId('account_id')->constrained()->restrictOnDelete();
 
                 $table->string("name");
                 $table->unsignedInteger("amount");

--- a/database/migrations/2026_04_04_052034_add_to_account_id_to_transactions_table.php
+++ b/database/migrations/2026_04_04_052034_add_to_account_id_to_transactions_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('transactions', function (Blueprint $table) {
-            $table->foreignId('to_account_id')->nullable()->after('account_id')->constrained('accounts')->nullOnDelete();
+            $table->foreignId('to_account_id')->nullable()->after('account_id')->constrained('accounts')->restrictOnDelete();
         });
     }
 

--- a/tests/Feature/Feature/Livewire/Accounts/DeleteAccountTest.php
+++ b/tests/Feature/Feature/Livewire/Accounts/DeleteAccountTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Livewire\Accounts;
+
+use App\Livewire\Accounts\AccountList;
+use App\Models\Account;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DeleteAccountTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    #[Test]
+    public function rekening_tanpa_transaksi_bisa_dihapus(): void
+    {
+        $account = Account::factory()->create(['user_id' => $this->user->id]);
+
+        Livewire::actingAs($this->user)
+            ->test(AccountList::class)
+            ->call('deleteAccount', $account->id)
+            ->assertDispatched('notify', function ($name, $params) {
+                return $params['type'] === 'success';
+            });
+
+        $this->assertDatabaseMissing('accounts', ['id' => $account->id]);
+    }
+
+    #[Test]
+    public function rekening_dengan_transaksi_as_source_tidak_bisa_dihapus(): void
+    {
+        $account = Account::factory()->create(['user_id' => $this->user->id]);
+        $category = Category::factory()->create(['user_id' => $this->user->id]);
+        
+        Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'account_id' => $account->id,
+            'category_id' => $category->id,
+        ]);
+
+        Livewire::actingAs($this->user)
+            ->test(AccountList::class)
+            ->call('deleteAccount', $account->id)
+            ->assertDispatched('notify', function ($name, $params) {
+                return $params['type'] === 'error' && str_contains($params['message'], 'tidak dapat dihapus');
+            });
+
+        $this->assertDatabaseHas('accounts', ['id' => $account->id]);
+    }
+
+    #[Test]
+    public function rekening_dengan_transaksi_as_destination_tidak_bisa_dihapus(): void
+    {
+        $sourceAccount = Account::factory()->create(['user_id' => $this->user->id]);
+        $destAccount = Account::factory()->create(['user_id' => $this->user->id]);
+        $category = Category::factory()->create(['user_id' => $this->user->id]);
+        
+        Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'account_id' => $sourceAccount->id,
+            'to_account_id' => $destAccount->id,
+            'category_id' => $category->id,
+            'type' => 'transfer',
+        ]);
+
+        Livewire::actingAs($this->user)
+            ->test(AccountList::class)
+            ->call('deleteAccount', $destAccount->id)
+            ->assertDispatched('notify', function ($name, $params) {
+                return $params['type'] === 'error' && str_contains($params['message'], 'tidak dapat dihapus');
+            });
+
+        $this->assertDatabaseHas('accounts', ['id' => $destAccount->id]);
+    }
+}


### PR DESCRIPTION
# Walkthrough: Account Deletion Protection

I have implemented a safety mechanism to prevent the deletion of accounts that still have associated transactions. This protection exists at both the database level and the application logic level.

## Changes Made

### 1. Database level Restriction
Updated existing migrations to change the deletion behavior from `cascade` (delete everything) to `restrict` (block deletion).
- **[2026_03_20_210309_create_transactions_table.php](file:///d:/Project/CatatanKeuangan/catatanKeuangan/database/migrations/2026_03_20_210309_create_transactions_table.php)**: Changed `account_id` to `restrictOnDelete()`.
- **[2026_04_04_052034_add_to_account_id_to_transactions_table.php](file:///d:/Project/CatatanKeuangan/catatanKeuangan/database/migrations/2026_04_04_052034_add_to_account_id_to_transactions_table.php)**: Changed `to_account_id` to `restrictOnDelete()`.

### 2. Application Logic Layer
Modified the `AccountList` component to check for transactions before attempting to delete an account.
- **[AccountList.php](file:///d:/Project/CatatanKeuangan/catatanKeuangan/app/Livewire/Accounts/AccountList.php)**: 
    - Added `exists()` check for both primary transactions and transfer destination transactions.
    - Used the `WithNotifications` trait for consistent error/success messages.

## Verification Results

### Automated Tests
I created a new feature test: **[DeleteAccountTest.php](file:///d:/Project/CatatanKeuangan/catatanKeuangan/tests/Feature/Feature/Livewire/Accounts/DeleteAccountTest.php)**.
- ✓ `rekening_tanpa_transaksi_bisa_dihapus`: PASSED
- ✓ `rekening_dengan_transaksi_as_source_tidak_bisa_dihapus`: PASSED
- ✓ `rekening_dengan_transaksi_as_destination_tidak_bisa_dihapus`: PASSED

### UI Verification
A manual UI walkthrough confirmed:
- **Restriction**: Attempting to delete "BCA Utama" (seeded with transactions) was blocked.
- **Success**: Creating a new "Test Account" and deleting it worked perfectly.
- **Feedback**: Appropriate error notifications are shown when deletion is blocked.

![UI Test Recording](file:///C:/Users/User/.gemini/antigravity/brain/87a4f699-90ba-4fa5-a866-c30604597de5/account_deletion_ui_test_1775311135317.webp)

> [!NOTE]
> I updated existing migrations as requested. To apply these changes in your local environment, you should run `php artisan migrate:fresh --seed`.
