### PR TITLE
fix: Perlindungan Penghapusan Category (Audit & Budget Fix)

### DIFF
--- a/app/Livewire/Transactions/Category.php
+++ b/app/Livewire/Transactions/Category.php
@@ -81,10 +81,11 @@ class Category extends Component
         // Check for existing transactions or favorite transactions
         $hasTransactions = \App\Models\Transaction::where('category_id', $id)->exists();
         $hasFavorites    = \App\Models\FavoriteTransaction::where('category_id', $id)->exists();
+        $hasBudgets      = \App\Models\Budget::withoutGlobalScopes()->where('category_id', $id)->exists();
 
-        if ($hasTransactions || $hasFavorites) {
-            $this->notify('Gagal!', 'Kategori ini masih digunakan oleh transaksi.', 'danger');
-            $this->errorMessage = 'Kategori ini tidak dapat dihapus karena masih digunakan oleh transaksi.';
+        if ($hasTransactions || $hasFavorites || $hasBudgets) {
+            $this->notify('Gagal!', 'Kategori ini masih digunakan oleh transaksi atau budget.', 'danger');
+            $this->errorMessage = 'Kategori ini tidak dapat dihapus karena masih digunakan oleh transaksi atau budget.';
             return;
         }
 

--- a/database/migrations/2026_03_23_210705_create_budgets_table.php
+++ b/database/migrations/2026_03_23_210705_create_budgets_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('budgets', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('category_id')->constrained('categories')->cascadeOnDelete();
+            $table->foreignId('category_id')->constrained('categories')->restrictOnDelete();
             $table->unsignedInteger('limit_amount');
             $table->tinyInteger('month');
             $table->year('year');

--- a/tests/Feature/CategoryDeletionTest.php
+++ b/tests/Feature/CategoryDeletionTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Livewire\Transactions\Category;
+use App\Models\Budget;
 use App\Models\Category as CategoryModel;
 use App\Models\FavoriteTransaction;
 use App\Models\Transaction;
@@ -31,7 +32,7 @@ class CategoryDeletionTest extends TestCase
 
         Livewire::test(Category::class)
             ->call('delete', $category->id)
-            ->assertSet('errorMessage', 'Kategori ini tidak dapat dihapus karena masih digunakan oleh transaksi.');
+            ->assertSet('errorMessage', 'Kategori ini tidak dapat dihapus karena masih digunakan oleh transaksi atau budget.');
 
         $this->assertDatabaseHas('categories', ['id' => $category->id]);
     }
@@ -55,7 +56,7 @@ class CategoryDeletionTest extends TestCase
 
         Livewire::test(Category::class)
             ->call('delete', $category->id)
-            ->assertSet('errorMessage', 'Kategori ini tidak dapat dihapus karena masih digunakan oleh transaksi.');
+            ->assertSet('errorMessage', 'Kategori ini tidak dapat dihapus karena masih digunakan oleh transaksi atau budget.');
 
         $this->assertDatabaseHas('categories', ['id' => $category->id]);
     }
@@ -73,5 +74,28 @@ class CategoryDeletionTest extends TestCase
             ->assertSet('errorMessage', '');
 
         $this->assertDatabaseMissing('categories', ['id' => $category->id]);
+    }
+
+    /** @test */
+    public function it_cannot_delete_category_with_existing_budget()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $category = CategoryModel::factory()->create(['user_id' => $user->id]);
+
+        // Create budget linked to this category
+        Budget::factory()->create([
+            'user_id'     => $user->id,
+            'category_id' => $category->id,
+            'month'       => now()->month,
+            'year'        => now()->year,
+        ]);
+
+        Livewire::test(Category::class)
+            ->call('delete', $category->id)
+            ->assertSet('errorMessage', 'Kategori ini tidak dapat dihapus karena masih digunakan oleh transaksi atau budget.');
+
+        $this->assertDatabaseHas('categories', ['id' => $category->id]);
     }
 }


### PR DESCRIPTION
## Summary

Implementasi proteksi penghapusan category dari relasi budget dan audit menyeluruh relasi category di database untuk menutup Issue #72.

## Perubahan

### ✏️ Diubah (Database Migration)
- \database/migrations/2026_03_23_210705_create_budgets_table.php\ — Mengubah foreign key \category_id\ dari \cascadeOnDelete()\ menjadi \estrictOnDelete()\. Hal ini mencegah kegagalan data budget saat kategori dihapus.

### ✏️ Diubah (Livewire Component)
- \pp/Livewire/Transactions/Category.php\ — Menambahkan pengecekan \Budget::exists()\ pada method \delete()\ sebelum kategori dihapus. Pesan error kini mencakup peringatan penggunaan budget.

### ✅ Diperbarui (Tests)
- \	ests/Feature/CategoryDeletionTest.php\ — Menambahkan test case baru untuk memvalidasi proteksi kategori yang memiliki budget (\it_cannot_delete_category_with_existing_budget\).

## Test Results

\\\
PASS  Tests\Feature\CategoryDeletionTest
✓ it cannot delete category with existing transactions
✓ it cannot delete category with existing favorite transactions
✓ it can delete category without transactions
✓ it cannot delete category with existing budget

Tests: 4 passed (8 assertions)
\\\

## Notes

> ⚠️ Karena file migration lama diperbarui, jalankan \php artisan migrate:fresh\ di env lokal.

Closes #72