### PR TITLE
fix: Undefined variable \ pada AccountList deletion

### DIFF
--- a/app/Livewire/Accounts/AccountList.php
+++ b/app/Livewire/Accounts/AccountList.php
@@ -50,7 +50,7 @@ class AccountList extends Component
     {
         $account = Account::findOrFail($this->deleteId);
 
-        if ($account->transactions()->exists() || \App\Models\Transaction::where('to_account_id', $id)->exists()) {
+        if ($account->transactions()->exists() || \App\Models\Transaction::where('to_account_id', $this->deleteId)->exists()) {
             $this->notify('Gagal menghapus', "Rekening {$account->name} tidak dapat dihapus karena masih memiliki riwayat transaksi.", 'error');
             return;
         }

--- a/tests/Feature/AccountDeletionTest.php
+++ b/tests/Feature/AccountDeletionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\Accounts\AccountList;
+use App\Models\Account;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AccountDeletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_cannot_delete_account_with_existing_transactions()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $account = Account::factory()->create(['user_id' => $user->id]);
+        
+        // Create transaction linked to this account
+        Transaction::factory()->create([
+            'user_id'    => $user->id,
+            'account_id' => $account->id,
+        ]);
+
+        Livewire::test(AccountList::class)
+            ->call('confirmDelete', $account->id)
+            ->assertSet('deleteId', $account->id)
+            ->call('delete')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('accounts', ['id' => $account->id]);
+    }
+
+    /** @test */
+    public function it_cannot_delete_account_with_incoming_transfer_transactions()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $fromAccount = Account::factory()->create(['user_id' => $user->id]);
+        $toAccount   = Account::factory()->create(['user_id' => $user->id]);
+        
+        // Create transfer transaction where this account is the destination (to_account_id)
+        Transaction::factory()->create([
+            'user_id'       => $user->id,
+            'account_id'    => $fromAccount->id,
+            'to_account_id' => $toAccount->id,
+            'type'          => 'transfer',
+        ]);
+
+        Livewire::test(AccountList::class)
+            ->call('confirmDelete', $toAccount->id)
+            ->call('delete');
+
+        $this->assertDatabaseHas('accounts', ['id' => $toAccount->id]);
+    }
+
+    /** @test */
+    public function it_can_delete_account_without_transactions()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $account = Account::factory()->create(['user_id' => $user->id]);
+
+        Livewire::test(AccountList::class)
+            ->call('confirmDelete', $account->id)
+            ->call('delete')
+            ->assertSet('deleteId', null);
+
+        $this->assertDatabaseMissing('accounts', ['id' => $account->id]);
+    }
+}


### PR DESCRIPTION
## Summary

Memperbaiki bug 'Variable \ not found' saat menghapus rekening yang tidak memiliki transaksi (Issue #76).

## Perubahan

### ✏️ Diubah
- \pp/Livewire/Accounts/AccountList.php\ — Mengganti variabel \\\ yang tidak terdefinisi menjadi \\->deleteId\ pada baris 53 di dalam method \delete()\.

### Audit Konsistensi
Saya telah melakukan audit ke seluruh komponen Livewire lainnya (\Transactions\Index\, \Transactions\QuickTransaction\, \Budgets\BudgetIndex\, \Transactions\Category\) dan memastikan penggunaan property \deleteId\ sudah konsisten dan tidak ada bug serupa.

### ✅ Ditambahkan (Tests)
- \	ests/Feature/AccountDeletionTest.php\ — Feature test baru untuk memvalidasi:
  - Rekening dengan transaksi keluar/masuk tidak dapat dihapus.
  - Rekening tanpa transaksi dapat dihapus dengan sukses tanpa error.

## Test Results

\\\
PASS  Tests\\Feature\\AccountDeletionTest
✓ it cannot delete account with existing transactions
✓ it cannot delete account with incoming transfer transactions
✓ it can delete account without transactions

Tests: 3 passed (6 assertions)
\\\

Closes #76