### PR TITLE
Feature: Account Support in Quick Transactions

### DIFF
--- a/app/Livewire/Transactions/Index.php
+++ b/app/Livewire/Transactions/Index.php
@@ -139,7 +139,10 @@ class Index extends Component
                 'amount'  => $trx->amount,
                 'type'    => $trx->type,
             ],
-            ['category_id' => $trx->category_id]
+            [
+                'category_id' => $trx->category_id,
+                'account_id'  => $trx->account_id,
+            ]
         );
         
         if ($fav->wasRecentlyCreated) {

--- a/app/Livewire/Transactions/QuickTransaction.php
+++ b/app/Livewire/Transactions/QuickTransaction.php
@@ -31,6 +31,11 @@ class QuickTransaction extends Component
     #[Validate('required', as: 'kategori')]
     public $editCategoryId = '';
 
+    #[Validate('required', as: 'rekening')]
+    public $editAccountId = '';
+
+    public $accounts = [];
+
     protected $listeners = [
         'favorite-created' => 'loadFavorites',
         'category-created' => 'loadCategories'
@@ -39,7 +44,13 @@ class QuickTransaction extends Component
     public function mount()
     {
         $this->loadCategories();
+        $this->loadAccounts();
         $this->loadFavorites();
+    }
+
+    public function loadAccounts()
+    {
+        $this->accounts = \App\Models\Account::where('user_id', auth()->id())->get();
     }
 
     public function loadCategories()
@@ -49,7 +60,7 @@ class QuickTransaction extends Component
 
     public function loadFavorites()
     {
-        $this->favorites = FavoriteTransaction::with('category')->get();
+        $this->favorites = FavoriteTransaction::with(['category', 'account'])->get();
     }
 
     // 1-click langsung save, date = hari ini
@@ -60,6 +71,7 @@ class QuickTransaction extends Component
         Transaction::create([
             'user_id'     => auth()->id(),
             'category_id' => $fav->category_id,
+            'account_id'  => $fav->account_id,
             'name'        => $fav->name,
             'amount'      => $fav->amount,
             'type'        => $fav->type,
@@ -80,6 +92,7 @@ class QuickTransaction extends Component
             'amount'      => $fav->amount,
             'type'        => $fav->type,
             'category_id' => $fav->category_id,
+            'account_id'  => $fav->account_id,
             'date'        => now()->toDateString(),
         ]);
 
@@ -96,6 +109,7 @@ class QuickTransaction extends Component
         $this->editAmount = $fav->amount;
         $this->editType = $fav->type;
         $this->editCategoryId = $fav->category_id;
+        $this->editAccountId = $fav->account_id;
         
         $this->dispatch('open-modal', 'modal-edit-favorite');
     }
@@ -111,6 +125,7 @@ class QuickTransaction extends Component
             'amount' => $this->editAmount,
             'type' => $this->editType,
             'category_id' => $this->editCategoryId,
+            'account_id' => $this->editAccountId,
         ]);
         
         $this->loadFavorites();

--- a/app/Livewire/Transactions/TransactionForm.php
+++ b/app/Livewire/Transactions/TransactionForm.php
@@ -143,6 +143,7 @@ class TransactionForm extends Component
         $this->amount      = $data['amount']      ?? null;
         $this->type        = $data['type']        ?? null;
         $this->category_id = $data['category_id'] ?? null;
+        $this->account_id  = $data['account_id']  ?? null;
         $this->date        = $data['date']        ?? null;
     }
 

--- a/app/Models/FavoriteTransaction.php
+++ b/app/Models/FavoriteTransaction.php
@@ -10,6 +10,7 @@ class FavoriteTransaction extends Model
     protected $fillable = [
         'user_id',
         'category_id',
+        'account_id',
         'name',
         'amount',
         'type',
@@ -23,5 +24,10 @@ class FavoriteTransaction extends Model
     public function category()
     {
         return $this->belongsTo(Category::class);
+    }
+
+    public function account()
+    {
+        return $this->belongsTo(Account::class);
     }
 }

--- a/database/migrations/2026_03_31_064950_create_favorite_transactions_table.php
+++ b/database/migrations/2026_03_31_064950_create_favorite_transactions_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->foreignId('category_id')->constrained('categories')->restrictOnDelete();
+            $table->foreignId('account_id')->nullable()->constrained('accounts')->onDelete('set null');
             $table->string('name');
             $table->unsignedInteger('amount');
             $table->enum('type', ['income', 'expense']);

--- a/resources/views/livewire/transactions/quick-transaction.blade.php
+++ b/resources/views/livewire/transactions/quick-transaction.blade.php
@@ -142,43 +142,77 @@
                     <!-- Nominal -->
                     <div x-data="{ 
                             display: '', 
-                            raw: '', 
+                            raw: @entangle('editAmount'), 
                             format(val) { 
                                 if (!val) return ''; 
                                 return val.toString().replace(/\D/g, '').replace(/\B(?=(\d{3})+(?!\d))/g, '.'); 
                             } 
                         }" 
                         x-init="
-                            $watch('$wire.editAmount', value => { 
-                                if(value) { 
-                                    raw = value.toString(); 
-                                    display = format(raw); 
-                                } else { 
-                                    display = ''; 
-                                    raw = ''; 
-                                } 
-                            })
+                            $watch('raw', value => { 
+                                display = format(value); 
+                            });
+                            display = format(raw);
                         " class="space-y-2">
-                        <label class="block text-sm font-medium text-gray-700">Nominal <span class="text-red-500">*</span></label>
+                        <label class="block text-sm font-semibold text-gray-700 tracking-tight">Nominal <span class="text-red-500">*</span></label>
                         <div class="relative">
                             <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
-                                <span class="text-gray-500 sm:text-sm font-medium">Rp</span>
+                                <span class="text-gray-500 sm:text-sm font-bold">Rp</span>
                             </div>
-                            <input type="text" x-model="display" @input="raw = display.replace(/\D/g, ''); display = format(raw); $wire.editAmount = raw;" class="block w-full rounded-xl border-0 py-3 pl-11 pr-4 text-gray-900 font-semibold shadow-sm ring-1 ring-inset ring-gray-200 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-base sm:leading-6 bg-gray-50/50 hover:bg-white transition-colors" placeholder="0">
+                            <input type="text" x-model="display" @input="raw = display.replace(/\D/g, ''); display = format(raw);" class="block w-full rounded-2xl border-0 py-4 pl-12 pr-4 text-gray-900 font-extrabold shadow-sm ring-1 ring-inset ring-gray-200 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 text-xl sm:leading-6 bg-white transition-all" placeholder="0">
                         </div>
                         @error('editAmount') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
                     </div>
 
-                    <!-- Kategori -->
+                    <!-- Kategori (Pill Selection) -->
                     <div class="space-y-2">
-                        <label class="block text-sm font-medium text-gray-700">Kategori <span class="text-red-500">*</span></label>
-                        <select wire:model="editCategoryId" class="block w-full rounded-xl border-0 py-3 pl-4 pr-10 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-200 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 appearance-none bg-gray-50/50 hover:bg-white transition-colors cursor-pointer">
-                            <option value="" class="text-gray-400">Pilih Kategori</option>
+                        <label class="block text-sm font-semibold text-gray-700 tracking-tight">Kategori <span class="text-red-500">*</span></label>
+                        <div class="flex flex-wrap gap-2 py-1">
                             @foreach ($categories as $category)
-                                <option value="{{ $category->id }}">{{ $category->name }}</option>
+                                <button
+                                    type="button"
+                                    wire:key="edit-category-{{ $category->id }}"
+                                    wire:click="$set('editCategoryId', {{ $category->id }})"
+                                    class="px-3 py-2 rounded-xl text-xs font-bold border transition-all duration-200 {{ $editCategoryId == $category->id ? 'bg-indigo-600 border-indigo-600 text-white shadow-md' : 'bg-white border-gray-200 text-gray-600 hover:border-gray-400' }}">
+                                    {{ $category->name }}
+                                </button>
                             @endforeach
-                        </select>
+                            @if($categories->isEmpty())
+                                <p class="text-xs text-gray-400 italic">Belum ada kategori</p>
+                            @endif
+                        </div>
                         @error('editCategoryId') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
+                    </div>
+                </div>
+
+                <!-- Pemilihan Rekening (Matching TransactionForm Style) -->
+                <div class="space-y-4">
+                    <div class="space-y-3">
+                        <label class="block text-sm font-semibold text-gray-700 tracking-tight">Rekening <span class="text-red-500">*</span></label>
+                        <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                            @foreach($accounts as $account)
+                                <button
+                                    type="button"
+                                    wire:key="edit-account-{{ $account->id }}"
+                                    wire:click="$set('editAccountId', {{ $account->id }})"
+                                    class="group relative flex flex-col items-center justify-center p-3 rounded-2xl border-2 transition-all duration-200 {{ $editAccountId == $account->id ? 'border-indigo-600 bg-indigo-50/50 shadow-sm' : 'border-gray-100 bg-white hover:border-gray-300 hover:bg-gray-50' }}">
+                                    <div class="w-10 h-10 flex items-center justify-center rounded-xl mb-2 {{ $editAccountId == $account->id ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-500 group-hover:bg-white' }}">
+                                        @if($account->type === 'bank')
+                                            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 10h18M7 15h1m4 0h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+                                            </svg>
+                                        @else
+                                            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z" />
+                                            </svg>
+                                        @endif
+                                    </div>
+                                    <span class="text-xs font-bold {{ $editAccountId == $account->id ? 'text-indigo-900' : 'text-gray-700' }} truncate w-full text-center">{{ $account->name }}</span>
+                                    <span class="text-[10px] text-gray-500 truncate w-full text-center">Rp {{ number_format($account->balance, 0, ',', '.') }}</span>
+                                </button>
+                            @endforeach
+                        </div>
+                        @error('editAccountId') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
                     </div>
                 </div>
 

--- a/tests/Feature/QuickTransactionAccountTest.php
+++ b/tests/Feature/QuickTransactionAccountTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\FavoriteTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class QuickTransactionAccountTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function favorite_transaction_stores_account_id()
+    {
+        $user     = User::factory()->create();
+        $account  = Account::factory()->create(['user_id' => $user->id]);
+        $category = Category::factory()->create(['user_id' => $user->id]);
+
+        $fav = FavoriteTransaction::create([
+            'user_id'     => $user->id,
+            'name'        => 'Beli Makan',
+            'amount'      => 50000,
+            'type'        => 'expense',
+            'category_id' => $category->id,
+            'account_id'  => $account->id,
+        ]);
+
+        $this->assertDatabaseHas('favorite_transactions', [
+            'id'         => $fav->id,
+            'account_id' => $account->id,
+        ]);
+    }
+
+    /** @test */
+    public function save_now_creates_transaction_with_correct_account_id()
+    {
+        $user     = User::factory()->create();
+        $account  = Account::factory()->create(['user_id' => $user->id]);
+        $category = Category::factory()->create(['user_id' => $user->id]);
+
+        $fav = FavoriteTransaction::create([
+            'user_id'     => $user->id,
+            'name'        => 'Beli Makan',
+            'amount'      => 50000,
+            'type'        => 'expense',
+            'category_id' => $category->id,
+            'account_id'  => $account->id,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(\App\Livewire\Transactions\QuickTransaction::class)
+            ->call('saveNow', $fav->id);
+
+        $this->assertDatabaseHas('transactions', [
+            'user_id'     => $user->id,
+            'account_id'  => $account->id,
+            'category_id' => $category->id,
+            'name'        => 'Beli Makan',
+            'amount'      => 50000,
+        ]);
+    }
+
+    /** @test */
+    public function prefill_dispatches_event_with_account_id()
+    {
+        $user     = User::factory()->create();
+        $account  = Account::factory()->create(['user_id' => $user->id]);
+        $category = Category::factory()->create(['user_id' => $user->id]);
+
+        $fav = FavoriteTransaction::create([
+            'user_id'     => $user->id,
+            'name'        => 'Beli Makan',
+            'amount'      => 50000,
+            'type'        => 'expense',
+            'category_id' => $category->id,
+            'account_id'  => $account->id,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(\App\Livewire\Transactions\QuickTransaction::class)
+            ->call('prefill', $fav->id)
+            ->assertDispatched('prefill-transaction', function ($event, $params) use ($account) {
+                return $params['data']['account_id'] === $account->id;
+            });
+    }
+
+    /** @test */
+    public function update_favorite_saves_new_account_id()
+    {
+        $user        = User::factory()->create();
+        $accountLama = Account::factory()->create(['user_id' => $user->id]);
+        $accountBaru = Account::factory()->create(['user_id' => $user->id]);
+        $category    = Category::factory()->create(['user_id' => $user->id]);
+
+        $fav = FavoriteTransaction::create([
+            'user_id'     => $user->id,
+            'name'        => 'Beli Makan',
+            'amount'      => 50000,
+            'type'        => 'expense',
+            'category_id' => $category->id,
+            'account_id'  => $accountLama->id,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(\App\Livewire\Transactions\QuickTransaction::class)
+            ->call('editFavorite', $fav->id)
+            ->set('editAccountId', $accountBaru->id)
+            ->call('updateFavorite');
+
+        $this->assertDatabaseHas('favorite_transactions', [
+            'id'         => $fav->id,
+            'account_id' => $accountBaru->id,
+        ]);
+    }
+
+    /** @test */
+    public function add_to_favorite_includes_account_id()
+    {
+        $user     = User::factory()->create();
+        $account  = Account::factory()->create(['user_id' => $user->id]);
+        $category = Category::factory()->create(['user_id' => $user->id]);
+        
+        $trx = Transaction::create([
+            'user_id'     => $user->id,
+            'account_id'  => $account->id,
+            'category_id' => $category->id,
+            'name'        => 'Gaji Bulanan',
+            'amount'      => 5000000,
+            'type'        => 'income',
+            'date'        => now()->toDateString(),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(\App\Livewire\Transactions\Index::class)
+            ->call('addToFavorite', $trx->id);
+
+        $this->assertDatabaseHas('favorite_transactions', [
+            'user_id'    => $user->id,
+            'account_id' => $account->id,
+            'name'       => 'Gaji Bulanan',
+            'amount'     => 5000000,
+        ]);
+    }
+}


### PR DESCRIPTION
Implement account_id support in Quick Transactions (issue #80). Includes database migration, model updates, Livewire UI overhaul with premium selection grid, and fix for addToFavorite account inheritance.